### PR TITLE
Fix unamed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ USER_FUNCTION_PORT=8090
 ## **Documentation**
 
 - [Actor options](./documentation/actor-options.md)
-  - [Unamed](./documentation/actor-options.md#unamed-actor)
+  - [Unnamed](./documentation/actor-options.md#unnamed-actor)
   - [Named](./documentation/actor-options.md#named-actor)
   - [Default Actions](./documentation/actor-options.md#default-actions)
 - [Actor workflows](./documentation/actor-workflows.md)

--- a/documentation/actor-options.md
+++ b/documentation/actor-options.md
@@ -2,9 +2,9 @@
 
 This is an example of what kind of Actors you can create with Spawn
 
-## Unamed Actor
+## Unnamed Actor
 
-In this example we are creating an actor in a Unamed way, that is, it is a known actor at compile time.
+In this example we are creating an actor in a Unnamed way, that is, it is a known actor at compile time.
 
 ```TS
 import spawn, { ActorContext, Kind, Value } from '@eigr/spawn-sdk'
@@ -14,9 +14,9 @@ const system = spawn.createSystem()
 
 // You can register multiple actors with different options
 const actor = system.buildActor({
-  name: 'unamedActorExample',
+  name: 'unnamedActorExample',
   stateType: UserState,
-  kind: Kind.UNAMED,
+  kind: Kind.UNNAMED,
   stateful: true,
   snapshotTimeout: 10_000n,
   deactivatedTimeout: 60_000n
@@ -42,7 +42,7 @@ It can be invoked with:
 import spawn, { payloadFor } from '@eigr/spawn-sdk'
 import { ChangeUserNamePayload, ChangeUserNameResponse } from 'src/protos/examples/user_example'
 
-spawn.invoke('unamedActorExample', {
+spawn.invoke('unnamedActorExample', {
   action: 'setName',
   response: ChangeUserNameResponse,
   payload: payloadFor(ChangeUserNamePayload, { newName: 'newName for actor' })

--- a/protos/eigr/functions/protocol/actors/actor.proto
+++ b/protos/eigr/functions/protocol/actors/actor.proto
@@ -94,11 +94,11 @@ enum Kind {
     // NAMED actors are used to create children of this based actor at runtime
     NAMED = 1;
 
-    // UNAMED actors as the name suggests have only one real instance of themselves running 
+    // UNNAMED actors as the name suggests have only one real instance of themselves running 
     // during their entire lifecycle. That is, they are the opposite of the NAMED type Actors.
-    UNAMED = 2;
+    UNNAMED = 2;
     
-    // Pooled Actors are similar to Unamed actors, but unlike them, 
+    // Pooled Actors are similar to Unnamed actors, but unlike them, 
     // their identifying name will always be the one registered at the system initialization stage. 
     // The great advantage of Pooled actors is that they have multiple instances of themselves 
     // acting as a request service pool.
@@ -143,7 +143,7 @@ message ActorId {
     // Name of a ActorSystem
     string system = 2;
 
-    // When the Actor is of the Unamed type, 
+    // When the Actor is of the Unnamed type, 
     // the name of the parent Actor must be informed here.
     string parent = 3;
 }

--- a/protos/eigr/functions/protocol/actors/protocol.proto
+++ b/protos/eigr/functions/protocol/actors/protocol.proto
@@ -58,7 +58,7 @@
 //
 // Actors are usually created at the beginning of the SDK's communication flow with the Proxy by the registration step described above. 
 // However, some use cases require that Actors can be created ***on the fly***. 
-// In other words, Spawn is used to bring to life Actors previously registered as Unameds, giving them a name and thus creating a concrete instance 
+// In other words, Spawn is used to bring to life Actors previously registered as Unnameds, giving them a name and thus creating a concrete instance 
 // at runtime for that Actor. Actors created with the Spawn feature are generally used when you want to share a behavior while maintaining 
 // the isolation characteristics of the actors.
 // For these situations we have the Spawning flow described below. 

--- a/src/client-actor/definitions.ts
+++ b/src/client-actor/definitions.ts
@@ -37,11 +37,11 @@ export type PooledActorOpts = IActorOpts & {
 export type ActorOpts = IActorOpts | PooledActorOpts
 
 export const defaultActorOpts = {
-  kind: Kind.UNAMED,
+  kind: Kind.UNNAMED,
   stateType: 'json',
   stateful: true,
-  snapshotTimeout: 10_000n,
-  deactivatedTimeout: 2_000n
+  snapshotTimeout: 3_000n,
+  deactivatedTimeout: 10_000n
 } as ActorOpts
 
 export const buildActorForSystem = (system: string, opts: ActorOpts): Actor => {

--- a/src/protos/eigr/functions/protocol/actors/actor.ts
+++ b/src/protos/eigr/functions/protocol/actors/actor.ts
@@ -244,7 +244,7 @@ export interface ActorId {
    */
   system: string
   /**
-   * When the Actor is of the Unamed type,
+   * When the Actor is of the Unnamed type,
    * the name of the parent Actor must be informed here.
    *
    * @generated from protobuf field: string parent = 3;
@@ -313,14 +313,14 @@ export enum Kind {
    */
   NAMED = 1,
   /**
-   * UNAMED actors as the name suggests have only one real instance of themselves running
+   * UNNAMED actors as the name suggests have only one real instance of themselves running
    * during their entire lifecycle. That is, they are the opposite of the NAMED type Actors.
    *
-   * @generated from protobuf enum value: UNAMED = 2;
+   * @generated from protobuf enum value: UNNAMED = 2;
    */
-  UNAMED = 2,
+  UNNAMED = 2,
   /**
-   * Pooled Actors are similar to Unamed actors, but unlike them,
+   * Pooled Actors are similar to Unnamed actors, but unlike them,
    * their identifying name will always be the one registered at the system initialization stage.
    * The great advantage of Pooled actors is that they have multiple instances of themselves
    * acting as a request service pool.

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -54,11 +54,11 @@ export type SpawnSystem = {
   /**
    * Builds an actor for this system with the following default options:
    *
-   * - kind: UNAMED
+   * - kind: UNNAMED
    * - stateType: 'json'
    * - stateful: true
-   * - snapshotTimeout: 10_000n
-   * - deactivatedTimeout: 2_000n
+   * - snapshotTimeout: 3_000n
+   * - deactivatedTimeout: 10_000n
    *
    * @param {ActorOpts} opts - options for creating the actor
    */


### PR DESCRIPTION
Our actors define a kind unamed, this fixes the typo to Unnamed properly.